### PR TITLE
Refactor for tooltips

### DIFF
--- a/data/tarot-data.json
+++ b/data/tarot-data.json
@@ -1,7 +1,4 @@
 {
-  "datasetAnnotations": {
-    "per_game_data.csv": "Basketball is a team sport in which two teams, most commonly of five players each, opposing one another on a rectangular court, compete with the primary objective of shooting a basketball (approximately 9.4 inches (24 cm) in diameter) through the defender's hoop (a basket 18 inches (46 cm) in diameter mounted 10 feet (3.048 m) high to a backboard at each end of the court) while preventing the opposing team from shooting through their own hoop. A field goal is worth two points, unless made from behind the three-point line, when it is worth three. After a foul, timed play stops and the player fouled or designated to shoot a technical foul is given one or more one-point free throws. The team with the most points at the end of the game wins, but if regulation play expires with the score tied, an additional period of play (overtime) is mandated."
-  },
   "layoutAnnotations": {
     "One Card": "Cupcake ipsum dolor sit. Amet I love liquorice jujubes pudding croissant I love pudding. Apple pie macaroon toffee jujubes pie tart cookie applicake caramels. Halvah macaroon I love lollipop. Wypas I love pudding brownie cheesecake tart jelly-o. Bear claw cookie chocolate bar jujubes toffee.",
     "Three Card": "Cupcake ipsum dolor sit. Amet I love liquorice jujubes pudding croissant I love pudding. Apple pie macaroon toffee jujubes pie tart cookie applicake caramels. Halvah macaroon I love lollipop. Wypas I love pudding brownie cheesecake tart jelly-o. Bear claw cookie chocolate bar jujubes toffee.",

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
         <div class="flex">
           <div class="select-label">Data set</div>
           <select id="dataset-selector">
-            <option disabled selected value> -- select an option -- </option>
+            <option disabled selected value> select a dataset </option>
             <option>per_game_data.csv</option>
             <option>per_game_data.csv</option>
             <option>per_game_data.csv</option>
@@ -44,15 +44,15 @@
           </select>
         </div>
 
-        <div class="description margin-bottom">
+        <!-- <div class="description margin-bottom">
           <h3>Description</h3>
-          <div id="dataset-description"></div>
-        </div>
+          <div id="dataset-description">Select a layout & Dataset to begin</div>
+        </div> -->
 
         <div class="flex">
           <div class="select-label">Layout</div>
           <select id="layout-selector">
-            <option disabled selected value> -- select an option -- </option>
+            <option disabled selected value> select a layout </option>
             <option value="One Card">One Card</option>
             <option value="Three Card">Three Card</option>
             <option value="Celtic Cross">Celtic Cross</option>
@@ -61,14 +61,15 @@
 
         <div class="description">
           <h3>Description</h3>
-          <div id="layout-description"></div>
+          <div id="layout-description">Select a layout & Dataset to begin</div>
         </div>
-
       </div>
       <div class="main-content">
         <h1 id="load-msg">SELECT A DATASET & LAYOUT TO BEGIN</h1>
-        <svg id="main-container"></svg>
+        <div id="main-container"></div>
       </div>
+
+
     </div>
   </div>
 </body>

--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
       <div class="main-content">
         <h1 id="load-msg">SELECT A DATASET & LAYOUT TO BEGIN</h1>
         <div id="main-container"></div>
+        <div id="tooltip"></div>
       </div>
 
 

--- a/src/draw.js
+++ b/src/draw.js
@@ -45,13 +45,7 @@ function drawCardSpaces(container, positions, scales) {
   cardSpace
     .append('div')
     .attr('class', 'cardspace')
-    // TODO this is wrong and doesnt handle the sideways one right
-    .style('transform', d => {
-      if (d.rotate) {
-        return `translate(${-xWindow(w) / 2}, ${yWindow(w)}) rotate(-90)`;
-      }
-      return `translate(${xWindow(w) * 0.05}, ${yWindow(h) * 0.05})`;
-    })
+    .style('transform', d => d.rotate && 'rotate(-90deg)')
     .style('width', `${xWindow(w) * 0.95}px`)
     .style('height', `${yWindow(h) * 0.95}px`);
 
@@ -97,11 +91,8 @@ function drawCards(container, positions, scales, cards) {
       .style('transform', () => {
         const xPos = xWindow(nextCardPos.x);
         const yPos = yWindow(nextCardPos.y);
-        if (!nextCardPos.rotate) {
-          return `translate(${xPos}px,${yPos}px)`;
-        }
-        return `translate(${xPos - 0.5 * xWindow(w)}px,${yPos +
-          xWindow(w) * 1.12}px) rotate(-90)`;
+        const rotate = nextCardPos.rotate ? 90 : 0;
+        return `translate(${xPos}px,${yPos}px) rotate(-${rotate}deg)`;
       });
     nextCardIdx += 1;
   }
@@ -147,11 +138,12 @@ function drawCards(container, positions, scales, cards) {
  */
 function oneCard(container) {
   // TODO select what we want EXAMPLE to be instead
-  const labels = ['*', 'EXAMPLE', '*'];
+  const CARD_NAME = 'EXAMPLE';
+  const labels = ['*', CARD_NAME, '*'];
   const scales = makeScales(container, labels);
   return {
     scales,
-    positions: [{x: scales.xScale('EXAMPLE'), y: 0.4, label: 'EXAMPLE'}]
+    positions: [{x: scales.xScale(CARD_NAME), y: 0.4, label: CARD_NAME}]
   };
 }
 

--- a/src/draw.js
+++ b/src/draw.js
@@ -24,79 +24,49 @@ function drawCardSpaces(container, positions, scales) {
     .enter()
     .append('div')
     .style('transform', d => `translate(${xWindow(d.x)}px, ${yWindow(d.y)}px)`)
-    .attr('class', 'cardcontainer');
+    .attr('class', 'cardcontainer')
+    .on('mousemove', function tooltiper() {
+      const [xPos, yPos] = d3.mouse(this);
+      d3.select(this)
+        .select('.tooltip')
+        .style('display', 'block')
+        .style('transform', `translate(${xPos}px, ${yPos}px)`);
+    })
+    .on('mouseout', function untip() {
+      d3.select(this)
+        .select('.tooltip')
+        .style('display', 'none');
+    });
   const cardSpace = cardContainers
     .append('div')
     .attr('class', 'cardspacecontainer');
 
+  // outline
   cardSpace
     .append('div')
     .attr('class', 'cardspace')
     // TODO this is wrong and doesnt handle the sideways one right
-    .style(
-      'transform',
-      d =>
-        (d.rotate &&
-          `translate(${-xWindow(w) / 2}, ${yWindow(w)}) rotate(-90)`) ||
-        `translate(${xWindow(w) * 0.05}, ${yWindow(h) * 0.05})`
-    )
-    .style('width', d => {
-      console.log(d, xWindow(w) * 0.95, `${xWindow(w) * 0.95}px`);
-      return `${xWindow(w) * 0.95}px`;
+    .style('transform', d => {
+      if (d.rotate) {
+        return `translate(${-xWindow(w) / 2}, ${yWindow(w)}) rotate(-90)`;
+      }
+      return `translate(${xWindow(w) * 0.05}, ${yWindow(h) * 0.05})`;
     })
-    .style('height', `${yWindow(h) * 0.95}px`)
-    .style('fill', '#333');
+    .style('width', `${xWindow(w) * 0.95}px`)
+    .style('height', `${yWindow(h) * 0.95}px`);
 
+  // title
   cardSpace
     .append('div')
     .attr('class', 'cardspace-title')
-    // .attr('x', xWindow(w / 2))
-    // .attr('y', yWindow(h / 2))
-    .attr('text-anchor', 'middle')
     .text(d => d.label);
 
-  // const TOOLTIP_WIDTH = 200;
-  // const TOOLTIP_HEIGHT = 100;
-  // const toolTipContainer = cardSpace
-  //   .append('div')
-  //   .attr('class', 'tooltip-container')
-  //   .attr(
-  //     'transform',
-  //     `translate(${xWindow(w / 2) - TOOLTIP_WIDTH / 2}, ${yWindow(h) -
-  //       TOOLTIP_HEIGHT / 2})`
-  //   );
-  // toolTipContainer
-  //   .append('foreignObject')
-  //   .attr('class', 'tooltip')
-  //   .attr('x', 0)
-  //   .attr('y', 0)
-  //   .attr('height', TOOLTIP_HEIGHT)
-  //   .attr('width', TOOLTIP_WIDTH)
-  //   .html(d => `<div class="tooltip">${tarotData.layouts[d.label]}</div>`);
+  // tooltip
+  cardSpace
+    .append('div')
+    .attr('class', 'tooltip')
+    .text(d => tarotData.layouts[d.label] || 'TODO: TOOLTIP FILL IN');
 }
-
-// UNUSED IN REFACTOR
-// function drawSidebar(container, scales) {
-//   const {xWindow, yWindow} = scales;
-//   container
-//     .append('rect')
-//     .attr('x', xWindow(0.9))
-//     .attr('y', yWindow(0))
-//     .attr('height', yWindow(1))
-//     .attr('width', xWindow(1.2) - xWindow(0.9))
-//     .attr('fill', 'lightgray');
-//
-//   container
-//     .append('foreignObject')
-//     .attr(
-//       'transform',
-//       () => `translate(${xWindow(0.95)},${yWindow(0.6) - 100})`
-//     )
-//     .attr('width', 200)
-//     .attr('height', 100)
-//     .append('xhtml:div')
-//     .html('Click the deck to draw a card');
-// }
 
 /**
  * draws the cards themselves, also contains state relevant to how many cards have been drawn
@@ -106,7 +76,7 @@ function drawCardSpaces(container, positions, scales) {
  * scales - an object of scales
  * positions - an array of objects describing the positioning and metadata with the card spaces
  */
-function drawCards(container, cards, scales, positions) {
+function drawCards(container, positions, scales, cards) {
   const {h, w} = getCardHeightWidth();
   const {xWindow, yWindow} = scales;
   // stateful incrementer of how deep into the draw we are, as the user draws more cards we increment this idx
@@ -138,8 +108,6 @@ function drawCards(container, cards, scales, positions) {
 
   // give the cards initial positioning to make it look like are in a pile
   cards.forEach((card, idx) => {
-    // card.x = 0.95 + (idx / 81) * 0.03;
-    // card.y = 0.6 + (idx / 81) * 0.03;
     card.x = idx;
     card.y = idx;
   });
@@ -166,8 +134,6 @@ function drawCards(container, cards, scales, positions) {
   card
     .append('div')
     .attr('class', 'card-back')
-    // .attr('x', 0)
-    // .attr('y', 0)
     .style('height', `${yWindow(h)}px`)
     .style('width', `${xWindow(w)}px`)
     .append('img')
@@ -249,7 +215,6 @@ function buildLayout(container, layout, cards) {
   // clear the contents of teh previous layout
   container.selectAll('*').remove();
   const {scales, positions} = layoutMethod[layout](container);
-  // drawSidebar(container, scales);
   drawCardSpaces(container, positions, scales);
-  drawCards(container, cards, scales, positions);
+  drawCards(container, positions, scales, cards);
 }

--- a/src/draw.js
+++ b/src/draw.js
@@ -25,17 +25,18 @@ function drawCardSpaces(container, positions, scales) {
     .append('div')
     .style('transform', d => `translate(${xWindow(d.x)}px, ${yWindow(d.y)}px)`)
     .attr('class', 'cardcontainer')
-    .on('mousemove', function tooltiper() {
-      const [xPos, yPos] = d3.mouse(this);
-      d3.select(this)
-        .select('.tooltip')
+    .on('mousemove', function tooltiper(d) {
+      const event = d3.event;
+      const xPos = event.layerX;
+      const yPos = event.layerY;
+      d3.select('#tooltip')
         .style('display', 'block')
-        .style('transform', `translate(${xPos}px, ${yPos}px)`);
+        .style('left', `${xPos}px`)
+        .style('top', `${yPos}px`)
+        .text(tarotData.layouts[d.label] || 'TODO: TOOLTIP FILL IN');
     })
     .on('mouseout', function untip() {
-      d3.select(this)
-        .select('.tooltip')
-        .style('display', 'none');
+      d3.select('#tooltip').style('display', 'none');
     });
   const cardSpace = cardContainers
     .append('div')
@@ -54,12 +55,6 @@ function drawCardSpaces(container, positions, scales) {
     .append('div')
     .attr('class', 'cardspace-title')
     .text(d => d.label);
-
-  // tooltip
-  cardSpace
-    .append('div')
-    .attr('class', 'tooltip')
-    .text(d => tarotData.layouts[d.label] || 'TODO: TOOLTIP FILL IN');
 }
 
 /**

--- a/src/draw.js
+++ b/src/draw.js
@@ -17,7 +17,7 @@ fetch('./data/tarot-data.json')
  */
 function drawCardSpaces(container, positions, scales) {
   const {xWindow, yWindow} = scales;
-  const {h, w} = getCardHeightWidth();
+  const {h, w} = getCardHeightWidth(scales);
 
   const containers = container.selectAll('.cardspacecontainer').data(positions);
   const cardContainers = containers
@@ -77,7 +77,7 @@ function drawCardSpaces(container, positions, scales) {
  * positions - an array of objects describing the positioning and metadata with the card spaces
  */
 function drawCards(container, positions, scales, cards) {
-  const {h, w} = getCardHeightWidth();
+  const {h, w} = getCardHeightWidth(scales);
   const {xWindow, yWindow} = scales;
   // stateful incrementer of how deep into the draw we are, as the user draws more cards we increment this idx
   let nextCardIdx = 0;
@@ -126,7 +126,7 @@ function drawCards(container, positions, scales, cards) {
     .append('div')
     .attr('class', 'card')
     .style('left', '-275px')
-    .style('bottom', '20%')
+    .style('bottom', '10%')
     .style('transform', d => `translate(${d.x}px,${d.y}px)`)
     .on('click', onCardClick);
   cardJoin.exit().remove();

--- a/src/main.js
+++ b/src/main.js
@@ -134,7 +134,6 @@ function main() {
   const mainContainer = d3.select('#main-container');
   const container = document.querySelector('.main-content');
   const {height, width} = container.getBoundingClientRect();
-  console.log(height, width);
 
   // update the state of the system based on changed inputs
   function stateUpdate() {

--- a/src/main.js
+++ b/src/main.js
@@ -133,7 +133,6 @@ function main() {
   // initialize everything
   const mainContainer = d3.select('#main-container');
   const container = document.querySelector('.main-content');
-  const {height, width} = container.getBoundingClientRect();
 
   // update the state of the system based on changed inputs
   function stateUpdate() {
@@ -151,7 +150,7 @@ function main() {
     }
 
     // size the mainContainer correctly
-    // TODO: AGHHHHH
+    const {height, width} = container.getBoundingClientRect();
     mainContainer.style('height', `${height}px`);
     mainContainer.style('width', `${width}px`);
 
@@ -193,6 +192,7 @@ function main() {
     });
 
   // TODO add listeners that allow user to upload a file here
+  window.onresize = stateUpdate;
 }
 
 // start the application after the content has loaded

--- a/src/main.js
+++ b/src/main.js
@@ -93,8 +93,9 @@ function emptyMinorArcana() {
  */
 function computeCards(data) {
   // majorArcanaData.concat(emptyMinorArcana())
-  const deck = majorArcanaData.concat(emptyMinorArcana());
-  // const deck = emptyMinorArcana();
+  // const deck = majorArcanaData.concat(emptyMinorArcana());
+  const deck = emptyMinorArcana();
+  // const deck = majorArcanaData;
   return shuffle(deck).map((x, idx) => ({
     // eslint appears to not like this line
     ...x,
@@ -130,9 +131,10 @@ function main() {
   };
 
   // initialize everything
-  const svg = d3.select('#main-container');
+  const mainContainer = d3.select('#main-container');
   const container = document.querySelector('.main-content');
   const {height, width} = container.getBoundingClientRect();
+  console.log(height, width);
 
   // update the state of the system based on changed inputs
   function stateUpdate() {
@@ -149,11 +151,13 @@ function main() {
       placeHolder.remove();
     }
 
-    // size the svg correctly
-    svg.attr('height', height).attr('width', width);
+    // size the mainContainer correctly
+    // TODO: AGHHHHH
+    mainContainer.style('height', `${height}px`);
+    mainContainer.style('width', `${width}px`);
 
     // draw the layout
-    buildLayout(svg, state.layout, state.cards);
+    buildLayout(mainContainer, state.layout, state.cards);
   }
 
   // listener for the layout selector
@@ -186,12 +190,6 @@ function main() {
         // TODO also do the data processing here
         stateUpdate();
       });
-
-      // update the description text
-      setDescription(
-        '#dataset-description',
-        tarotData.datasetAnnotations[state.datasetName]
-      );
       stateUpdate();
     });
 

--- a/src/main.js
+++ b/src/main.js
@@ -93,8 +93,8 @@ function emptyMinorArcana() {
  */
 function computeCards(data) {
   // majorArcanaData.concat(emptyMinorArcana())
-  // const deck = majorArcanaData.concat(emptyMinorArcana());
-  const deck = emptyMinorArcana();
+  const deck = majorArcanaData.concat(emptyMinorArcana());
+  // const deck = emptyMinorArcana();
   // const deck = majorArcanaData;
   return shuffle(deck).map((x, idx) => ({
     // eslint appears to not like this line

--- a/src/style.css
+++ b/src/style.css
@@ -118,17 +118,14 @@ body{
   background: #333333;
   border-radius: 5px;
   color: white;
-    font-family: 'Playfair Display', serif;
+  display: none;
+  font-family: 'Playfair Display', serif;
   font-size: 12px;
   padding: 10px;
   position: absolute;
   pointer-events: none;
   width: 200px;
-  display: none;
   z-index: 1000;
-}
-.cardfront-container {
-  /* position: relative; */
 }
 
 .cardfront-background {
@@ -151,9 +148,7 @@ body{
   width: calc(100% - 20px);
   padding: 20px;
 }
-/* .cardfront-main { */
-  /* pointer-events: none; */
-/* } */
+
 .cardfront-background,
 .cardfront-main {
   left: -10px;

--- a/src/style.css
+++ b/src/style.css
@@ -35,6 +35,32 @@ body{
   margin-bottom: 30px;
 }
 
+.main-container {
+  position: relative;
+}
+
+.cardcontainer {
+  position: absolute;
+}
+
+.card {
+  position: absolute;
+}
+.card-back {
+  border: thin solid black;
+  background: black;
+  border-radius: 10px;
+}
+.card-back img {
+  height: 100%;
+  width: 100%;
+}
+
+.cardspace-title {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+}
 
 
 /* SECTIONS */
@@ -59,11 +85,16 @@ body{
   padding: 30px;
 }
 
+#deck-holder {
+  position: absolute;
+}
+
 .main-content {
   align-items: center;
   display: flex;
   flex-direction: column;
   height: 100%;
+  position: relative;
   justify-content: center;
   width: 100%;
 }
@@ -77,6 +108,10 @@ body{
 .cardspace:hover {
     fill-opacity: 1;
 }
+
+.tooltip-container {
+  position: absolute;
+}
 .cardspacecontainer .tooltip-container,
 .cardfront-container .tooltip-container {
   opacity: 0;
@@ -86,22 +121,45 @@ body{
 .cardspacecontainer:hover .tooltip-container,
 .cardfront-container:hover .tooltip-container {
   opacity: 1;
-  /* pointer-events: all; */
+}
+.cardfront-container {
+  position: relative;
+}
+
+.cardfront-background {
+  border: 7px solid black;
+  background: white;
+  height: 100%;
+  width: 100%;
+  border-radius: 10px;
+  position: absolute;
+  z-index: 0;
+
+}
+.cardfront-main {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  height: calc(100% - 20px);
+  width: calc(100% - 20px);
+  padding: 20px;
+}
+.cardfront-background,
+.cardfront-main {
+  left: -10px;
+  top: -6px
+}
+
+.cardfront-label {
+
+  font-size: 10px;
+  /* text-anchor: middle; */
 }
 
 .card {
   cursor: pointer;
-}
-
-.cardback-img {
-  height: 100%;
-  width: 100%;
-  /* background: green; */
-  overflow: hidden;
-}
-
-.cardback-img img {
-  width: 100%;
 }
 
 .tooltip {
@@ -165,7 +223,7 @@ select option {
 
 
 .vega-container {
-  display: flex !important;
+  display: flex;
   align-items: center;
   justify-content: center;
   height: 100%;

--- a/src/style.css
+++ b/src/style.css
@@ -116,6 +116,12 @@ body{
 }
 
 .tooltip {
+  background: #333333;
+  border-radius: 5px;
+  color: white;
+    font-family: 'Playfair Display', serif;
+  font-size: 12px;
+  padding: 10px;
   position: absolute;
   width: 200px;
   display: none;
@@ -156,16 +162,6 @@ body{
 
 .card {
   cursor: pointer;
-}
-
-.tooltip {
-  background: #333333;
-  border-radius: 5px;
-  color: white;
-    font-family: 'Playfair Display', serif;
-  font-size: 12px;
-  padding: 10px;
-  /* z-index: 10000; */
 }
 
 

--- a/src/style.css
+++ b/src/style.css
@@ -110,9 +110,9 @@ body{
     transition: background 0.5s;
     z-index: 0;
 }
-/* .cardspace:hover {
+.cardspace:hover {
     background: gray;
-} */
+}
 
 #tooltip {
   background: #333333;

--- a/src/style.css
+++ b/src/style.css
@@ -55,11 +55,18 @@ body{
   height: 100%;
   width: 100%;
 }
-
-.cardspace-title {
-  align-items: center;
+.cardspacecontainer {
   display: flex;
+  align-items: center;
   justify-content: center;
+  position: relative;
+}
+.cardspace-title {
+  /* align-items: center;
+  display: flex;
+  justify-content: center; */
+  position: absolute;
+
 }
 
 
@@ -100,39 +107,30 @@ body{
 }
 
 .cardspace {
-    fill: gray;
-    fill-opacity: 0;
+    background: white;
     outline: 2px dashed #333;
-    transition: fill-opacity 1s;
+    transition: background 0.5s;
 }
 .cardspace:hover {
-    fill-opacity: 1;
+    background: gray;
 }
 
-.tooltip-container {
+.tooltip {
   position: absolute;
-}
-.cardspacecontainer .tooltip-container,
-.cardfront-container .tooltip-container {
-  opacity: 0;
-  pointer-events: none;
-
-}
-.cardspacecontainer:hover .tooltip-container,
-.cardfront-container:hover .tooltip-container {
-  opacity: 1;
+  width: 200px;
+  display: none;
 }
 .cardfront-container {
   position: relative;
 }
 
 .cardfront-background {
-  border: 7px solid black;
   background: white;
-  height: 100%;
-  width: 100%;
+  border: 7px solid black;
   border-radius: 10px;
+  height: 100%;
   position: absolute;
+  width: 100%;
   z-index: 0;
 
 }
@@ -153,9 +151,7 @@ body{
 }
 
 .cardfront-label {
-
   font-size: 10px;
-  /* text-anchor: middle; */
 }
 
 .card {

--- a/src/style.css
+++ b/src/style.css
@@ -62,10 +62,8 @@ body{
   position: relative;
 }
 .cardspace-title {
-  /* align-items: center;
-  display: flex;
-  justify-content: center; */
   position: absolute;
+  pointer-events: none;
 
 }
 
@@ -112,11 +110,11 @@ body{
     transition: background 0.5s;
     z-index: 0;
 }
-.cardspace:hover {
+/* .cardspace:hover {
     background: gray;
-}
+} */
 
-.tooltip {
+#tooltip {
   background: #333333;
   border-radius: 5px;
   color: white;
@@ -124,12 +122,13 @@ body{
   font-size: 12px;
   padding: 10px;
   position: absolute;
+  pointer-events: none;
   width: 200px;
   display: none;
   z-index: 1000;
 }
 .cardfront-container {
-  position: relative;
+  /* position: relative; */
 }
 
 .cardfront-background {
@@ -152,6 +151,9 @@ body{
   width: calc(100% - 20px);
   padding: 20px;
 }
+/* .cardfront-main { */
+  /* pointer-events: none; */
+/* } */
 .cardfront-background,
 .cardfront-main {
   left: -10px;
@@ -171,6 +173,7 @@ body{
   display: flex;
   align-items: center;
   justify-content: center;
+  pointer-events: none;
   height: 100%;
   width: 100%;
 }
@@ -178,8 +181,6 @@ body{
 .card-title {
   display: flex;
   justify-content: center;
-  width: 100%;
-  height: 100%;
   text-align: center;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -110,6 +110,7 @@ body{
     background: white;
     outline: 2px dashed #333;
     transition: background 0.5s;
+    z-index: 0;
 }
 .cardspace:hover {
     background: gray;
@@ -125,6 +126,7 @@ body{
   position: absolute;
   width: 200px;
   display: none;
+  z-index: 1000;
 }
 .cardfront-container {
   position: relative;

--- a/src/tarot.js
+++ b/src/tarot.js
@@ -26,7 +26,6 @@ const emojii = [
 
 /**
  * Handles the parts of the card layout which are common to all cards.
- * Returns a d3 selection of the partially constructed card
  *
  * domNode - the dom node that is relevent to the card
  * card - an object containing the cards data
@@ -36,21 +35,31 @@ const emojii = [
 function cardCommon(domNode, card, scales, middleContent) {
   const {xWindow, yWindow} = scales;
   const {h, w} = getCardHeightWidth();
-  const container = d3.select(domNode).attr('id', `card-${card.pos}`);
+  // tooltip defined after the container, but the container needs referece to it shruggie
+  let tooltipNode = null;
+
+  const container = d3
+    .select(domNode)
+    .attr('id', `card-${card.pos}`)
+    .on('mousemove', function tooltip() {
+      const [xPos, yPos] = d3.mouse(this);
+      tooltipNode
+        .style('display', 'block')
+        .style('transform', `translate(${xPos}px, ${yPos}px)`);
+    })
+    .on('mouseout', () => tooltipNode.style('display', 'none'));
+
   container.selectAll('*').remove();
   let cardContainer = container
     .append('div')
     .style('height', `${yWindow(h)}px`)
     .style('width', `${xWindow(w)}px`);
 
+  // reverse trans not current used
+  const reverseTrans = `rotate(-180) translate(-${xWindow(w)}, -${yWindow(h)})`;
   cardContainer
     .attr('class', `cardfront-container`)
-    .style(
-      'transform',
-      card.reversed
-        ? `rotate(-180) translate(-${xWindow(w)}, -${yWindow(h)})`
-        : ''
-    );
+    .style('transform', card.reversed ? reverseTrans : '');
   // background
   cardContainer.append('div').attr('class', 'cardfront-background');
 
@@ -75,26 +84,23 @@ function cardCommon(domNode, card, scales, middleContent) {
       .style('width', `${xWindow(w)}px`)
       .html(() => `<div class="card-title">${card.cardtitle}</div>`);
   }
-
-  const TOOLTIP_WIDTH = 200;
-  const TOOLTIP_HEIGHT = 100;
-  const toolTipContainer = cardContainer
-    .append('div')
-    .attr('class', 'tooltip-container')
-    .style(
-      'transform',
-      `translate(${xWindow(w / 2) - TOOLTIP_WIDTH / 2}, ${yWindow(h) -
-        TOOLTIP_HEIGHT / 2})`
-    );
-  toolTipContainer
+  //
+  // const TOOLTIP_WIDTH = 200;
+  // const TOOLTIP_HEIGHT = 100;
+  tooltipNode = cardContainer
+    // .append('div')
+    // .attr('class', 'tooltip-container')
+    // .style(
+    //   'transform',
+    //   `translate(${xWindow(w / 2) - TOOLTIP_WIDTH / 2}, ${yWindow(h) -
+    //     TOOLTIP_HEIGHT / 2})`
+    // )
     .append('div')
     .attr('class', 'tooltip')
-    .style('height', `${TOOLTIP_HEIGHT}px`)
-    .style('width', `${TOOLTIP_WIDTH}px`)
-    .html(
-      () => `<div class="tooltip"><b>${card.cardtitle}</b>: ${card.tip}</div>`
-    );
-  return cardContainer;
+    // .style('height', `${TOOLTIP_HEIGHT}px`)
+    // .style('width', `${TOOLTIP_WIDTH}px`)
+
+    .html(`<div><b>${card.cardtitle}</b>: ${card.tip}</div>`);
 }
 
 /**

--- a/src/tarot.js
+++ b/src/tarot.js
@@ -34,7 +34,7 @@ const emojii = [
  */
 function cardCommon(domNode, card, scales, middleContent) {
   const {xWindow, yWindow} = scales;
-  const {h, w} = getCardHeightWidth();
+  const {h, w} = getCardHeightWidth(scales);
   // tooltip defined after the container, but the container needs referece to it shruggie
   let tooltipNode = null;
 
@@ -84,22 +84,10 @@ function cardCommon(domNode, card, scales, middleContent) {
       .style('width', `${xWindow(w)}px`)
       .html(() => `<div class="card-title">${card.cardtitle}</div>`);
   }
-  //
-  // const TOOLTIP_WIDTH = 200;
-  // const TOOLTIP_HEIGHT = 100;
+
   tooltipNode = cardContainer
-    // .append('div')
-    // .attr('class', 'tooltip-container')
-    // .style(
-    //   'transform',
-    //   `translate(${xWindow(w / 2) - TOOLTIP_WIDTH / 2}, ${yWindow(h) -
-    //     TOOLTIP_HEIGHT / 2})`
-    // )
     .append('div')
     .attr('class', 'tooltip')
-    // .style('height', `${TOOLTIP_HEIGHT}px`)
-    // .style('width', `${TOOLTIP_WIDTH}px`)
-
     .html(`<div><b>${card.cardtitle}</b>: ${card.tip}</div>`);
 }
 
@@ -110,8 +98,9 @@ function cardCommon(domNode, card, scales, middleContent) {
  * card - an object containing the cards data
  * scales - an object of the scales for positioning things
  */
-function minorArcana(domNode, card, {xWindow, yWindow}) {
-  const {h, w} = getCardHeightWidth();
+function minorArcana(domNode, card, scales) {
+  const {xWindow, yWindow} = scales;
+  const {h, w} = getCardHeightWidth(scales);
 
   domNode
     .append('div')

--- a/src/tarot.js
+++ b/src/tarot.js
@@ -44,7 +44,6 @@ function cardCommon(domNode, card, scales, cardContent) {
       const targetingChart = event.vegaType;
       const xPos = event.layerX;
       const yPos = event.layerY;
-      console.log(event, xPos, yPos);
       d3.select('#tooltip')
         .style('display', targetingChart ? 'none' : 'block')
         .style('left', `${xPos}px`)
@@ -109,13 +108,9 @@ function minorArcana(domNode, card, scales) {
     'per_game_data'
   );
   setTimeout(() => {
-    vegaEmbed(`#card-${card.pos} .vega-container`, spec, {actions: false})
-      // .then(function(result) {
-      //   domNode.querySelector('.lds-dual-ring').remove();
-      //   // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
-      //   console.log('view', result);
-      // })
-      .catch(console.error);
+    vegaEmbed(`#card-${card.pos} .vega-container`, spec, {
+      actions: false
+    }).catch(console.error);
   }, 750);
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,12 +4,12 @@
  *
  * the xWindow and yWindow scales refer to the full viewing pane, and use index coordinates (e.g. 0 to 1)
  *
- * svg - the d3 selection for the full svg pane
+ * container - the d3 selection for the full container pane
  * labels - an array of entities (strings, numbers whatever) to determine the behaviour of the band scale
  */
-function makeScales(svg, labels) {
-  const width = parseInt(svg.style('width'));
-  const height = parseInt(svg.style('height'));
+function makeScales(container, labels) {
+  const width = parseInt(container.style('width'));
+  const height = parseInt(container.style('height'));
   const margin = {
     left: 0,
     right: 0,
@@ -18,7 +18,7 @@ function makeScales(svg, labels) {
   };
   const xWindow = d3
     .scaleLinear()
-    .domain([0, 1.2])
+    .domain([0, 1])
     .range([margin.left, width - margin.left - margin.right]);
   const yWindow = d3
     .scaleLinear()

--- a/src/utils.js
+++ b/src/utils.js
@@ -37,12 +37,14 @@ function makeScales(container, labels) {
 
 /**
  * Util method for determining the size in index space of the cards, returns an object
+ * scales object that comes from make scales
  */
-function getCardHeightWidth() {
-  const size = 0.3;
-  let h = size;
-  let w = (57.15 / 88.9) * size;
-  return {h, w};
+function getCardHeightWidth(scales) {
+  const DESIRED_WIDTH = 175;
+  return {
+    h: scales.yWindow.invert(DESIRED_WIDTH * (88.9 / 57.15)),
+    w: scales.xWindow.invert(DESIRED_WIDTH)
+  };
 }
 
 /**


### PR DESCRIPTION
This PR wraps up almost all of the design issues that have been outstanding. It does so through a sizable refactor which changes the application from working on SVGs to working on DOM nodes. This was necessary to resolve the ambiguity between cards layers which was preventing tooltips from working cleanly (foreignobjects are v messy)

This wraps up #1 and #3, and makes a passable hack at #8  

![wiggly-boys](https://user-images.githubusercontent.com/6854312/71535305-b6411200-28b9-11ea-9fa0-d3602c4a0231.gif)
 