### PR TITLE
arcana type sampling

### DIFF
--- a/src/draw.js
+++ b/src/draw.js
@@ -207,5 +207,16 @@ function buildLayout(container, layout, cards, dataset) {
   container.selectAll('*').remove();
   const {scales, positions} = layoutMethod[layout](container);
   drawCardSpaces(container, positions, scales);
-  drawCards(container, positions, scales, cards, dataset);
+
+  //shuffle cards
+  if(layout == 'One Card'){
+    deck = shuffleCards(cards.minor);
+  }else{
+    // sub-sample the major arcana so that it mathces
+    // number of possible minor arcana cards
+    let samp_size = cards.major.length > cards.minor.length ? cards.minor.length : cards.major.length
+    let majorSubsample= cards.major.sample(samp_size); // 
+    deck = shuffleCards(majorSubSample.concat(cards.minor));
+  }
+  drawCards(container, positions, scales, deck, dataset);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -94,10 +94,13 @@ function computeCards(data) {
     {dimension: [], measure: [], null: []}
   );
 
-  const deck = majorArcanaData.concat(emptyMinorArcana(groupedTypes));
+  //const deck = majorArcanaData.concat(emptyMinorArcana(groupedTypes));
+  // return cards in order,  shuffle later
+  // makes sampling easier
   // const deck = emptyMinorArcana();
   // const deck = majorArcanaData;
-  return shuffle(deck).map((x, idx) => ({
+
+ /* return shuffle(deck).map((x, idx) => ({
     // eslint appears to not like this line
     ...x,
     pos: idx,
@@ -106,6 +109,10 @@ function computeCards(data) {
     // reversed: Math.random() > 0.5
     reversed: false
   }));
+  */
+
+  const deck = {"major": majorArcanaData, "minor": emptyMinorArcana(groupedTypes)};
+  return deck;
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -91,3 +91,22 @@ function toRomanNumeral(idx) {
 String.prototype.capitalize = function() {
   return this.charAt(0).toUpperCase() + this.slice(1);
 };
+
+
+//moving card shuffling to a general purpose util
+function shuffleCards(deck) {
+  return shuffle(deck).map((x, idx) => ({
+  // eslint appears to not like this line
+  ...x,
+  pos: idx,
+  index: Math.random(),
+  // for now reversed is hard to read, so its disabled
+  // reversed: Math.random() > 0.5
+  reversed: false
+}));
+}
+
+// Sampling without replacement
+Array.prototype.sample = function(n) {
+  return shuffleCards(this).slice(0,n);
+};


### PR DESCRIPTION
Added sampling for arcana. The major arcana will be sub-sampled according to the viable minor arcana cards (code still to be written by @mcorrell). Changed data structure from array (prior default) to dictionary to simplify the sampling process. Moved card shuffling to later.

Also added some rules for the card draws (single card layout always draws from the minor arcana). 